### PR TITLE
Remove etc cert prepend

### DIFF
--- a/app/handlers/apiv1/user.go
+++ b/app/handlers/apiv1/user.go
@@ -9,7 +9,6 @@ import (
 	"github.com/getfider/fider/app/models/query"
 	"github.com/getfider/fider/app/pkg/bus"
 	"github.com/getfider/fider/app/pkg/errors"
-	"github.com/getfider/fider/app/pkg/log"
 	"github.com/getfider/fider/app/pkg/web"
 )
 

--- a/app/pkg/web/engine.go
+++ b/app/pkg/web/engine.go
@@ -101,8 +101,8 @@ func (e *Engine) Start(address string) {
 	)
 
 	if env.Config.SSLCert != "" {
-		certFilePath = env.Etc(env.Config.SSLCert)
-		keyFilePath = env.Etc(env.Config.SSLCertKey)
+		certFilePath = env.Config.SSLCert
+		keyFilePath = env.Config.SSLCertKey
 	}
 
 	stdLog.SetOutput(ioutil.Discard)


### PR DESCRIPTION
…the env variable a true path as opposed to an assumed path

**Issue:**  Fider made the assumtion that i would want to prepend my cert path with 'etc' which is a bad assumption as it is typical to pass in the full path to the certs.

**Resolution:** To fix this I removed the `env.Etc()` call wrapping the path that is passed in as an environment variable.

**Issue:**  additional unused import

**Resolution:** remove